### PR TITLE
Add multiprocessing guard to examples

### DIFF
--- a/examples/using_agama/rotating_bar.py
+++ b/examples/using_agama/rotating_bar.py
@@ -51,10 +51,13 @@ def ic_function(x, vy, z):
 
 dt = 0.01 * u.Gyr
 steps = 500
-tanal = TessellationAnalysis(
-    ic_function, values, pot, dt, steps, pattern_speed=omega, pidgey_chunksize=50
-)
-tanal.launch_interactive_plot("x", "vy")
 
-tanal.save(f"examples/using_galpy/bar_{SIZE}_{FRAMES}.hdf5")
-tanal.launch_interactive_plot("x", "vy")
+if __name__ == '__main__':
+
+    tanal = TessellationAnalysis(
+        ic_function, values, pot, dt, steps, pattern_speed=omega, pidgey_chunksize=50
+    )
+    tanal.launch_interactive_plot("x", "vy")
+
+    tanal.save(f"examples/using_galpy/bar_{SIZE}_{FRAMES}.hdf5")
+    tanal.launch_interactive_plot("x", "vy")

--- a/examples/using_gala/rotating_bar.py
+++ b/examples/using_gala/rotating_bar.py
@@ -56,10 +56,13 @@ def ic_function(x, vy, z):
 
 dt = 0.01 * u.Gyr
 steps = 500
-tanal = TessellationAnalysis(
-    ic_function, values, pot, dt, steps, pattern_speed=omega, pidgey_chunksize=50
-)
-tanal.launch_interactive_plot("x", "vy")
 
-tanal.save(f"examples/using_galpy/bar_{SIZE}_{FRAMES}.hdf5")
-tanal.launch_interactive_plot("x", "vy")
+if __name__ == '__main__':
+
+    tanal = TessellationAnalysis(
+        ic_function, values, pot, dt, steps, pattern_speed=omega, pidgey_chunksize=50
+    )
+    tanal.launch_interactive_plot("x", "vy")
+
+    tanal.save(f"examples/using_galpy/bar_{SIZE}_{FRAMES}.hdf5")
+    tanal.launch_interactive_plot("x", "vy")

--- a/examples/using_galpy/rotating_bar.py
+++ b/examples/using_galpy/rotating_bar.py
@@ -45,10 +45,13 @@ def ic_function(x, vy, z):
 
 dt = 0.01 * u.Gyr
 steps = 500
-tanal = TessellationAnalysis(
-    ic_function, values, pot, dt, steps, pattern_speed=omega, pidgey_chunksize=50
-)
-tanal.launch_interactive_plot("x", "vy")
 
-tanal.save(f"examples/using_galpy/bar_{SIZE}_{FRAMES}.hdf5")
-tanal.launch_interactive_plot("x", "vy")
+
+if __name__ == '__main__':
+    tanal = TessellationAnalysis(
+        ic_function, values, pot, dt, steps, pattern_speed=omega, pidgey_chunksize=50
+    )
+    tanal.launch_interactive_plot("x", "vy")
+
+    tanal.save(f"examples/using_galpy/bar_{SIZE}_{FRAMES}.hdf5")
+    tanal.launch_interactive_plot("x", "vy")


### PR DESCRIPTION
At least on my machine (M1 MacBook Air), the examples were producing a horrifying error log, which can simplify to 
```
RuntimeError:
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...
```

I believe this is because macOS uses `spawn` to create new processes. This was easily fixed by adding a guard, as done in the commit. I believe this will still be fine on unix and Windows systems as well.