### PR TITLE
Joss documentation changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ See the [documentation](https://commensurability.readthedocs.io/en/latest/) page
 
 This package is to be used along with one of the galactic dynamics packages [`agama`](https://github.com/GalacticDynamics-Oxford/Agama), [`gala`](https://gala-astro.readthedocs.io/en/latest/), or [`galpy`](https://docs.galpy.org/en/latest/).
 There are scripts for each under the `examples` folder that can be run to test whether everything is working correctly.
+
+## Contributing
+
+If you wish to contribute to ``commensurability``, please fork the repository and create a [pull request](https://github.com/ilikecubesnstuff/commensurability/pulls).
+
+If you wish to report bugs, request features or suggest other ideas, please open an [issue](https://github.com/ilikecubesnstuff/commensurability/issues).
+
+For more information, see [contributing] in the documentation.

--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ If you wish to contribute to ``commensurability``, please fork the repository an
 
 If you wish to report bugs, request features or suggest other ideas, please open an [issue](https://github.com/ilikecubesnstuff/commensurability/issues).
 
-For more information, see [contributing] in the documentation.
+For more information, see [contributing](https://commensurability.readthedocs.io/en/latest/contributing/) in the documentation.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,19 @@
+# Contributing
+
+Thank you so much for your interest in contributing to `commensurability`!
+
+## Reporting Issues
+
+Please report bugs & other problems by opening an [issue](https://github.com/ilikecubesnstuff/commensurability/issues) on GitHub.
+
+You may want to check the existing issues for [`commensurability`](https://github.com/ilikecubesnstuff/commensurability/issues?q=is%3Aissue) and [`pidgey`](https://github.com/ilikecubesnstuff/pidgey/issues?q=is%3Aissue) in case your specific report has already been made.
+
+## Contributing Code
+
+Please fork the repository and create a [pull request](https://github.com/ilikecubesnstuff/commensurability/pulls) to contribute code.
+
+### Contributing a New Commensurability Evaluation Method
+
+New commensurability evaluation methods should be contained in a subpackage of commensurability, like `tessellation`.
+This package should provide an `Evaluation` instance for analysis classes to use.
+The corresponding analysis classes can be defined in `analysis.py`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,14 +22,22 @@ pip install .
 
 ## Orbit Integration Backends
 
-``commensurability`` can work on pre-computed files of integrated orbits and
-therefore does not strictly require any orbit integration backend to be
-installed. This is why ``commensurability`` does not install any such library.
-However, if you are not working with a pre-computed file and need
-``commensurability`` to integrate a grid of orbits you will need to have an
-orbit integration library installed (e.g. `agama`, `gala`, or `galpy`). Chances
-are you probably do! ``commensurability`` automatically installs and uses
-[``pidgey``](https://pypi.org/project/pidgey/) to support many different
-libraries. Check out [``pidgey``](https://pypi.org/project/pidgey/) to see
-whether your preferred library is supported, or how to register it with
-``pidgey`` if it isn't.
+`commensurability` can work on pre-computed files of integrated orbits and therefore does not strictly require any orbit integration backend to be installed.
+This is why `commensurability` does not install any such library.
+However, if you are not working with a pre-computed file and need `commensurability` to integrate a grid of orbits you will need to have an orbit integration library installed (e.g. `agama`, `gala`, or `galpy`) that is supported by [`pidgey`](https://pypi.org/project/pidgey/).
+[`pidgey`](https://pypi.org/project/pidgey/) states:
+
+> **To use `pidgey`, you require one of the following galactic dynamics libraries installed.**
+> 
+> | Package | Installation Instructions |
+> | ------- | ------------------------- |
+> | [`agama`](https://github.com/GalacticDynamics-Oxford/Agama)* | [https://github.com/GalacticDynamics-Oxford/Agama/blob/master/INSTALL](https://github.com/GalacticDynamics-Oxford/Agama/blob/master/INSTALL) |
+> | [`gala`](https://github.com/adrn/gala)                       | [https://gala.adrian.pw/en/latest/install.html](https://gala.adrian.pw/en/latest/install.html) |
+> | [`galpy`](https://github.com/jobovy/galpy)                   | [https://docs.galpy.org/en/stable/installation.html](https://docs.galpy.org/en/stable/installation.html) |
+> 
+> ***Note**: Currently, `pidgey` supports [this version of `agama`](https://github.com/GalacticDynamics-Oxford/Agama/tree/0c5993d1c631d9a9e8f48213f919e09bfd629639) (commit hash [0c5993d](https://github.com/GalacticDynamics-Oxford/Agama/tree/0c5993d1c631d9a9e8f48213f919e09bfd629639)).
+> `agama` requires WSL on Windows, as well as a C++ compiler.
+> After you clone the repository, you may require running an explicit `python setup.py install --user` - this installation pattern is only supported for Python versions <=3.11.
+
+`commensurability` depends on [`pidgey`](https://pypi.org/project/pidgey/) to support many different orbit integration backends.
+Check out [`pidgey`](https://pypi.org/project/pidgey/) to see whether your preferred library is supported, or how to register it with `pidgey` if it isn't.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
 - Motivation: motivation.md
 - Installation: installation.md
 - Quickstart: quickstart.md
+- Contributing: contributing.md
 - Tessellation:
   - tessellation/index.md
   - Implementation: tessellation/implementation.md


### PR DESCRIPTION
Add installation links for agama/gala/galpy (resolves #25) and clarify contribution guidelines (resolves #26).
Issues referenced are under https://github.com/openjournals/joss-reviews/issues/7009.