### PR TITLE
build: add astropy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 dependencies = [
     "pidgey>=1.0.0",
+    "astropy>=6.1",
     "matplotlib>=3.8.2",
     "tqdm>=4.66.1",
     "h5py>=3.10.0",


### PR DESCRIPTION
PDM had astropy v5 stuff in it. Maybe if that's removed then this dependency can be upstreamed to pidgey and not included in the dependency list here.

— https://github.com/openjournals/joss-reviews/issues/7009