### PR TITLE
fix: add required equivalency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name = "ilikecubesnstuff", email = "25328250+ilikecubesnstuff@users.noreply.github.com" },
 ]
 dependencies = [
-    "pidgey>=1.0.0",
+    "pidgey>=1.0.3",
     "matplotlib>=3.8.2",
     "tqdm>=4.66.1",
     "h5py>=3.10.0",

--- a/src/commensurability/analysis.py
+++ b/src/commensurability/analysis.py
@@ -366,21 +366,20 @@ class MPAnalysisBase(AnalysisBase):
             total=self.size // pidgey_chunksize,
             disable=not progressbar,
         ):
-            coords = [
-                self.ic_function(*(self.ic_values[ax][i] for i, ax in zip(pixel, self.axis_names)))
-                for pixel in pixels
-            ]
+            coords = []
+            for pixel in pixels:
+                params = [self.ic_values[ax][i] for i, ax in zip(pixel, self.axis_names)]
+                coord = self.ic_function(*params)
+                coords.append(coord)
             coords = collapse_coords(coords)
 
-            # TODO: this is a hack that should be fixed in pidgey
-            with u.add_enabled_equivalencies(u.dimensionless_angles()):
-                orbits = self.backend.compute_orbit(
-                    coords,
-                    self.potential,
-                    self.dt,
-                    self.steps,
-                    pattern_speed=self.pattern_speed,
-                )
+            orbits = self.backend.compute_orbit(
+                coords,
+                self.potential,
+                self.dt,
+                self.steps,
+                pattern_speed=self.pattern_speed,
+            )
             with Pool() as p:
                 values = list(
                     tqdm(

--- a/src/commensurability/analysis.py
+++ b/src/commensurability/analysis.py
@@ -366,11 +366,10 @@ class MPAnalysisBase(AnalysisBase):
             total=self.size // pidgey_chunksize,
             disable=not progressbar,
         ):
-            coords = []
-            for pixel in pixels:
-                params = [self.ic_values[ax][i] for i, ax in zip(pixel, self.axis_names)]
-                coord = self.ic_function(*params)
-                coords.append(coord)
+            coords = [
+                self.ic_function(*(self.ic_values[ax][i] for i, ax in zip(pixel, self.axis_names)))
+                for pixel in pixels
+            ]
             coords = collapse_coords(coords)
 
             # TODO: this is a hack that should be fixed in pidgey

--- a/src/commensurability/analysis.py
+++ b/src/commensurability/analysis.py
@@ -373,13 +373,15 @@ class MPAnalysisBase(AnalysisBase):
                 coords.append(coord)
             coords = collapse_coords(coords)
 
-            orbits = self.backend.compute_orbit(
-                coords,
-                self.potential,
-                self.dt,
-                self.steps,
-                pattern_speed=self.pattern_speed,
-            )
+            # TODO: this is a hack that should be fixed in pidgey
+            with u.add_enabled_equivalencies(u.dimensionless_angles()):
+                orbits = self.backend.compute_orbit(
+                    coords,
+                    self.potential,
+                    self.dt,
+                    self.steps,
+                    pattern_speed=self.pattern_speed,
+                )
             with Pool() as p:
                 values = list(
                     tqdm(


### PR DESCRIPTION
When I do a clean install in a fresh environment this equivalency is not automatically set up. It's required for pidgey to do its thing.
This fix should probably be upstreamed to pidgey.

— https://github.com/openjournals/joss-reviews/issues/7009